### PR TITLE
CD-423 Library and template for overriding in the sub theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ of the Common Design where the Global Search is adapted for this.
 There are two sets of configurations required:
 'Google config', on the Google site at
 https://programmablesearchengine.google.com/controlpanel/all
-'Module config', on the OCHA site at
+'Internal config', on the OCHA site at
 /admin/config/search/gcse-config
 
 Search results will appear at `/results` unless set to another path in the 'internal config'. This is to avoid conflict with `/search` as that path may
@@ -56,11 +56,12 @@ advanced tab in the setup, then the name and description edited accordingly.
 All the color preferences and some other styling choices are included in a
 css file in the module, so configuration of those in the can be ignored.
 
-### Module config
-The GCSE ID for the current site, found on the Google configuration page:
-Optional local settings:
-The path for the results page for site-only search, if a different path than
+### Internal config
+* The path for the results page for site-only search, if a different path than
 '/results'.
-The path for the results page for Ocha-wide search, if a different path than
+* The path for the results page for Ocha-wide search, if a different path than
 '/ocha-wide-results'.
-A descriptive text for the search results pages.
+* A descriptive text for the site search results page.
+* A descriptive text for the OCHA-wide search results pages.
+* The GCSE ID for the current site search, found on the Google config page.
+* The GCSE ID for the OCHA-wide search, normally 92f65997481234c49.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,20 @@ This modules provides basic configuration and two search results pages for
 results from Google Custom Search Engine searches - one, to be configured, for
 the site the module is installed on, the other for OCHA-wide results.
 
-## Additional setup
-The search box and the styling should be added to the subtheme.
-@TODO add a link to the CD PR where the search box is adapted for this.
+## Additional setup in the subtheme
+The search box for the Global Search should be added to the subtheme template.
+Optionally, the result page template can overridden in the subtheme , and the
+styling can be extended by a subtheme library.
+
+`common_design_subtheme.info.yml`
+```
+ibraries-extend:
+  ocha_search/google-cse:
+    - common_design_subtheme/google-cse
+```
+
+See https://github.com/UN-OCHA/common-design-site/pull/214/files for an example
+of the Common Design where the search box is adapted for this.
 
 ## Configuration
 There are two sets of configurations required:
@@ -16,7 +27,7 @@ https://programmablesearchengine.google.com/controlpanel/all
 'Module config', on the OCHA site at
 /admin/config/search/gcse-config
 
-Search results will appear at `/results` unless set to another path in the 'internal config'. This is to avoid conflict with `/search` as that path may 
+Search results will appear at `/results` unless set to another path in the 'internal config'. This is to avoid conflict with `/search` as that path may
 already be defined by other modules.
 
 It requires a GCSE ID, which comes from the Google config page.
@@ -28,7 +39,7 @@ gcse_config directory. It can be uploaded to a custom search engine via the
 advanced tab in the setup, then the name and description edited accordingly.
 
 All the color preferences and some other styling choices are included in a
-css file in the theme, so configuration of those in the can be ignored.
+css file in the module, so configuration of those in the can be ignored.
 
 ### Module config
 The GCSE ID for the current site, found on the Google configuration page:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,22 @@ results from Google Custom Search Engine searches - one, to be configured, for
 the site the module is installed on, the other for OCHA-wide results.
 
 ## Additional setup in the subtheme
-The search box for the Global Search should be added to the subtheme template.
-Optionally, the result page template can overridden in the subtheme , and the
+The search form for the Global Search should be added to the subtheme template,
+specifically with the form's action value set to `/{{ results_page_path }}`
+
+The `results_page_path` vairable is available with a preprocess function added
+to the subtheme:
+```
+/**
+ * Implements hook_preprocess_page().
+ */
+function common_design_subtheme_preprocess_page(&$variables) {
+  // Get results page path - default to 'results'.
+  $variables['results_page_path'] = \Drupal::config('ocha_search.settings')->get('site_results_page_path') ?? 'results';
+}
+```
+
+Optionally, the result page template can overridden in the subtheme, and the
 styling can be extended by a subtheme library.
 
 `common_design_subtheme.info.yml`
@@ -18,7 +32,7 @@ libraries-extend:
 ```
 
 See https://github.com/UN-OCHA/common-design-site/pull/214/files for an example
-of the Common Design where the search box is adapted for this.
+of the Common Design where the Global Search is adapted for this.
 
 ## Configuration
 There are two sets of configurations required:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ the site the module is installed on, the other for OCHA-wide results.
 
 ## Additional setup in the subtheme
 The search form for the Global Search should be added to the subtheme template,
-specifically with the form's action value set to `/{{ results_page_path }}`
+specifically with the form's action value set to `/{{ results_page_path }}` and
+the `input name="q"` which is the GCSE default.
 
-The `results_page_path` vairable is available with a preprocess function added
+The `results_page_path` variable is available with a preprocess function added
 to the subtheme:
 ```
 /**
@@ -21,7 +22,7 @@ function common_design_subtheme_preprocess_page(&$variables) {
 }
 ```
 
-Optionally, the result page template can overridden in the subtheme, and the
+Optionally, the result page template can be overridden in the subtheme, and the
 styling can be extended by a subtheme library.
 
 `common_design_subtheme.info.yml`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ styling can be extended by a subtheme library.
 
 `common_design_subtheme.info.yml`
 ```
-ibraries-extend:
+libraries-extend:
   ocha_search/google-cse:
     - common_design_subtheme/google-cse
 ```

--- a/css/google-cse.css
+++ b/css/google-cse.css
@@ -1,0 +1,175 @@
+/* stylelint-disable selector-id-pattern, selector-class-pattern */
+/**
+ * Override Google custom search engine
+ *
+ * All selectors are exact duplicates of the Google-provided selectors so that
+ * we can override them.
+ */
+
+/**
+ * Overrides of decisions that can be made in the UI.
+ *
+ * These to make sure site admins don't make 'non-cd' changes.
+ */
+.gcs-control-cse,
+.gsc-control-cse .gsc-table-result {
+  font-family: var(--cd-font-roboto) !important;
+}
+
+input.gsc-input,
+.gsc-input-box,
+.gsc-input-box-hover,
+.gsc-input-box-focus {
+  border-color: var(--cd-blue-grey) !important;
+}
+
+.gsc-search-button-v2,
+.gsc-search-button-v2:hover,
+.gsc-search-button-v2:focus {
+  border-color: var(--cd-ocha-blue) !important;
+  background-color: var(--cd-ocha-blue) !important;
+  background-image: none !important;
+  filter: none !important;
+}
+
+.gsc-search-button-v2 svg {
+  fill: var(--cd-white) !important;
+}
+
+.gsc-tabHeader.gsc-tabhActive,
+.gsc-refinementHeader.gsc-refinementhActive,
+.gsc-tabHeader.gsc-tabhInactive,
+.gsc-refinementHeader.gsc-refinementhInactive {
+  color: var(--cd-grey--dark) !important;
+  border-color: var(--cd-grey--dark) !important;
+  background-color: var(--cd-white) !important;
+}
+
+.gsc-webResult.gsc-result,
+.gsc-results .gsc-imageResult,
+.gsc-webResult.gsc-result:hover {
+  border-color: var(--cd-white) !important;
+  background-color: var(--cd-white) !important;
+}
+
+.gsc-completion-snippet,
+.gs-webResult:not(.gs-no-results-result):not(.gs-error-result) .gs-snippet,
+.gs-fileFormatType {
+  color: var(--cd-grey--dark) !important;
+}
+
+.gs-webResult.gs-result a.gs-title:link,
+.gs-webResult.gs-result a.gs-title:link b,
+.gs-imageResult a.gs-title:link,
+.gs-imageResult a.gs-title:link b,
+.gs-webResult.gs-result a.gs-title:visited,
+.gs-webResult.gs-result a.gs-title:visited b,
+.gs-imageResult a.gs-title:visited,
+.gs-imageResult a.gs-title:visited b,
+.gs-webResult.gs-result a.gs-title:hover,
+.gs-webResult.gs-result a.gs-title:hover b,
+.gs-imageResult a.gs-title:hover,
+.gs-imageResult a.gs-title:hover b,
+.gs-webResult.gs-result a.gs-title:active,
+.gs-webResult.gs-result a.gs-title:active b,
+.gs-imageResult a.gs-title:active,
+.gs-imageResult a.gs-title:active b,
+.gsc-cursor-page,
+a.gsc-trailing-more-results:link,
+.gs-webResult div.gs-visibleUrl,
+.gs-webResult div.gs-visibleUrl-short,
+.gsc-completion-title {
+  color: var(--cd-blue--dark) !important;
+}
+
+.gs-webResult div.gs-visibleUrl-long {
+  display: block !important;
+}
+
+.gs-webResult div.gs-visibleUrl-short,
+.gs-webResult div.gs-visibleUrl-breadcrumb {
+  display: none !important;
+}
+
+.gsc-cursor-box {
+  border-color: var(--cd-white) !important;
+}
+
+.gsc-results .gsc-cursor-box .gsc-cursor-page,
+.gsc-results .gsc-cursor-box .gsc-cursor-current-page {
+  border-color: var(--cd-grey--dark) !important;
+  background-color: var(--cd-white) !important;
+  color: var(--cd-grey--dark) !important;
+}
+
+/**
+ * Other overrides for styling consistency.
+ */
+.gsc-adBlock {
+  display: none !important;
+}
+
+/* Hides the 'All' tab as we're only using refinements. */
+/* .gsc-refinementBlock > div:first-child {
+  display: none !important;
+} */
+
+.gcsc-more-maybe-branding-root {
+  display: none !important;
+}
+
+.gsc-control-cse {
+  padding: 0 !important;
+  border: none !important;
+}
+
+form.gsc-search-box {
+  margin-bottom: 0 !important;
+}
+
+@media screen and (min-width: 1200px) {
+  form.gsc-search-box {
+    margin-right: auto !important;
+    margin-left: auto !important;
+  }
+}
+
+.gsib_a {
+  padding: 9px !important;
+}
+
+/* mobile+en.css */
+.gsc-input-box {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.gsc-input {
+  padding-right: 0 !important;
+}
+
+/* override CD Table default margin */
+.gsc-input table {
+  margin-bottom: 0;
+}
+
+.gsc-search-button {
+  margin-left: 0 !important;
+}
+
+.gsc-search-button-v2 {
+  height: 44px !important;
+  padding-right: 16px !important;
+  padding-left: 16px !important;
+}
+
+.gsc-above-wrapper-area,
+.gsc-wrapper {
+  max-width: 1140px;
+  margin: 0 auto;
+}
+
+/* Horizontal spacing between the thumbnail and entry */
+.gs-image-box {
+  margin-inline-end: 0.5rem !important;
+}

--- a/ocha_search.libraries.yml
+++ b/ocha_search.libraries.yml
@@ -1,0 +1,4 @@
+google-cse:
+  css:
+    theme:
+      css/google-cse.css: {}

--- a/templates/results-page.html.twig
+++ b/templates/results-page.html.twig
@@ -13,9 +13,12 @@
  */
 #}
 
-{{ attach_library('common_design/cd-tabs') }}
-{{ attach_library('common_design_subtheme/google-cse') }}
+{% block library %}
+  {{ attach_library('ocha_search/google-cse') }}
+  {{ attach_library('common_design/cd-tabs') }}
+{% endblock %}
 
+{% block search %}
 <div class="gcse-results-page">
   <script async defer src="https://cse.google.com/cse.js?cx={{ gcse_id }}"></script>
 
@@ -28,11 +31,12 @@
     </li>
   </ul>
 
-  <div class="gcse-searchbox-only" data-resultsUrl="{{ url('<current>') }}"></div>
-
   {% if search_text %}
-  <p class="gcse-search-custom-text">{{ search_text }}</p>
+    <p class="gcse-search-custom-text">{{ search_text }}</p>
   {% endif %}
+
+  <div class="gcse-searchbox-only" data-resultsUrl="{{ url('<current>') }}"></div>
 
   <div class="gcse-searchresults-only"></div>
 </div>
+{% endblock %}


### PR DESCRIPTION
See CD-423 for description
- move search text above search input
- define and attach library for GCSE styles in the module
- wrap template markup in twig blocks for easy overriding in sub theme

This corresponds with recent additions to https://github.com/UN-OCHA/common-design-site/pull/214