### PR TITLE
Use own block

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ the site the module is installed on, the other for OCHA-wide results.
 
 ## Additional setup in the subtheme
 
-Copy `templates/block--ocha-search-block.html.twig` to your custom theme.
-
-Optionally, the result page template can be overridden in the subtheme, and the
+The result page template can be overridden in the subtheme, and the
 styling can be extended by a subtheme library.
 
 `common_design_subtheme.info.yml`

--- a/README.md
+++ b/README.md
@@ -1,41 +1,26 @@
 # OCHA search module
-============================
 
 This modules provides basic configuration and two search results pages for
 results from Google Custom Search Engine searches - one, to be configured, for
 the site the module is installed on, the other for OCHA-wide results.
 
 ## Additional setup in the subtheme
-The search form for the Global Search should be added to the subtheme template,
-specifically with the form's action value set to `/{{ results_page_path }}` and
-the `input name="q"` which is the GCSE default.
 
-The `results_page_path` variable is available with a preprocess function added
-to the subtheme:
-```
-/**
- * Implements hook_preprocess_page().
- */
-function common_design_subtheme_preprocess_page(&$variables) {
-  // Get results page path - default to 'results'.
-  $variables['results_page_path'] = \Drupal::config('ocha_search.settings')->get('site_results_page_path') ?? 'results';
-}
-```
+Copy `templates/block--ocha-search-block.html.twig` to your custom theme.
 
 Optionally, the result page template can be overridden in the subtheme, and the
 styling can be extended by a subtheme library.
 
 `common_design_subtheme.info.yml`
-```
+
+```yaml
 libraries-extend:
   ocha_search/google-cse:
     - common_design_subtheme/google-cse
 ```
 
-See https://github.com/UN-OCHA/common-design-site/pull/214/files for an example
-of the Common Design where the Global Search is adapted for this.
-
 ## Configuration
+
 There are two sets of configurations required:
 'Google config', on the Google site at
 https://programmablesearchengine.google.com/controlpanel/all
@@ -49,6 +34,7 @@ It requires a GCSE ID, which comes from the Google config page.
 That ID must be added on the module config page.
 
 ### Google config
+
 The 'standard' configuration options are included in an xml file in the
 gcse_config directory. It can be uploaded to a custom search engine via the
 advanced tab in the setup, then the name and description edited accordingly.
@@ -57,6 +43,7 @@ All the color preferences and some other styling choices are included in a
 css file in the module, so configuration of those in the can be ignored.
 
 ### Internal config
+
 * The path for the results page for site-only search, if a different path than
 '/results'.
 * The path for the results page for Ocha-wide search, if a different path than

--- a/config/optional/block.block.ochasearch.yml
+++ b/config/optional/block.block.ochasearch.yml
@@ -1,0 +1,20 @@
+uuid: 8a0e8ae7-7e3e-4c96-825e-e5f5184a2268
+langcode: en
+status: true
+dependencies:
+  module:
+    - ocha_search
+  theme:
+    - common_design_subtheme
+id: ochasearch
+theme: common_design_subtheme
+region: header_search
+weight: 0
+provider: null
+plugin: ocha_search_block
+settings:
+  id: ocha_search_block
+  label: 'OCHA Search'
+  label_display: '0'
+  provider: ocha_search
+visibility: {  }

--- a/ocha_search.module
+++ b/ocha_search.module
@@ -10,6 +10,12 @@
  */
 function ocha_search_theme($existing, $type, $theme, $path) {
   return [
+    'ocha_search_block' => [
+      'template' => 'ocha-search-block',
+      'variables' => [
+        'results_page_path' => NULL,
+      ],
+    ],
     'ocha_search_results_page' => [
       'template' => 'results-page',
       'variables' => [

--- a/src/Plugin/Block/OchaSearchBlock.php
+++ b/src/Plugin/Block/OchaSearchBlock.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\ocha_search\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a GCSE search block.
+ *
+ * @Block(
+ * id = "ocha_search_block",
+ * admin_label = @Translation("OCHA Search"),
+ * )
+ */
+class OchaSearchBlock extends Blockbase implements ContainerFactoryPluginInterface {
+
+  /**
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $results_page_path = $this->configFactory->get('ocha_search.settings')->get('site_results_page_path') ?? 'results';
+
+    return [
+      '#theme' => 'ocha_search_block',
+      '#results_page_path' => $results_page_path,
+    ];
+  }
+
+}

--- a/templates/block--ocha-search-block.html.twig
+++ b/templates/block--ocha-search-block.html.twig
@@ -1,0 +1,3 @@
+{% block content %}
+  {{ content }}
+{% endblock %}

--- a/templates/block--ocha-search-block.html.twig
+++ b/templates/block--ocha-search-block.html.twig
@@ -1,3 +1,0 @@
-{% block content %}
-  {{ content }}
-{% endblock %}

--- a/templates/ocha-search-block.html.twig
+++ b/templates/ocha-search-block.html.twig
@@ -1,6 +1,4 @@
 <div class="cd-search">
-  {{ attach_library('ocha_search/google-cse') }}
-
   <div class="cd-search__form" aria-labelledby="cd-search-btn" data-cd-toggable="Search" data-cd-component="cd-search" data-cd-logo="search" data-cd-focus-target="cd-search" id="block-searchform" role="search">
     <h2 class="visually-hidden">{% trans %}Search form{% endtrans %}</h2>
     <form action="/{{ results_page_path }}" method="get" accept-charset="UTF-8">

--- a/templates/ocha-search-block.html.twig
+++ b/templates/ocha-search-block.html.twig
@@ -1,0 +1,23 @@
+<div class="cd-search">
+  {{ attach_library('ocha_search/google-cse') }}
+
+  <div class="cd-search__form" aria-labelledby="cd-search-btn" data-cd-toggable="Search" data-cd-component="cd-search" data-cd-logo="search" data-cd-focus-target="cd-search" id="block-searchform" role="search">
+    <h2 class="visually-hidden">{% trans %}Search form{% endtrans %}</h2>
+    <form action="/{{ results_page_path }}" method="get" accept-charset="UTF-8">
+      <div class="form--inline clearfix">
+        <div class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-keys form-item-keys">
+          <label for="cd-search">{% trans %}Search{% endtrans %}</label>
+          <input placeholder="What are you looking for?" class="cd-search__input form-text" type="text" id="cd-search" name="q" value="{{ keyword }}" size="30" maxlength="128" autocomplete="off">
+        </div>
+        <div class="form-actions js-form-wrapper form-wrapper">
+          <button data-twig-suggestion="search_submit" class="cd-search__submit button js-form-submit form-submit" value="Search" type="submit">
+            <svg class="cd-icon cd-icon--search" width="16" height="16" aria-hidden="true" focusable="false">
+              <use xlink:href="#cd-icon--search"></use>
+            </svg>
+            <span class="visually-hidden">Search</span>
+          </button>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>


### PR DESCRIPTION
`html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-site-header.html.twig` can be simplified to

```twig
<div class="cd-site-header">
  <div class="cd-container cd-site-header__inner">

    {% include '@common_design/cd/cd-header/cd-logo.html.twig' %}

    <div class="cd-site-header__actions">

      {% if page.header_search %}

        {{ page.header_search }}

      {% endif %}

      {% include '@common_design/cd/cd-header/cd-navigation.html.twig' %}

    </div>
  </div>
</div>
```