### PR TITLE
fix: allow ocha-wide search to be turned off

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # OCHA search module
 
-This modules provides basic configuration and two search results pages for
-results from Google Custom Search Engine searches - one, to be configured, for
-the site the module is installed on, the other for OCHA-wide results.
+This module provides basic configuration and one or two search results pages
+for results from Google Custom Search Engine searches:
+ * one, to be configured, for the site the module is installed on,
+ * the other, optional, for OCHA-wide results.
+
+## Google Indexing
+
+To use GCSE effectively as an in-site search, the site’s content needs to be
+indexed by Google.
+We use Drupal xmlsitemap module to provide a sitemap and we can submit that to
+Google for indexing. This requires access to Google Search console which can be
+requested via digitalservices@humanitarianresponse.info
 
 ## Additional setup in the subtheme
 
@@ -29,28 +38,39 @@ https://programmablesearchengine.google.com/controlpanel/all
 'Internal config', on the OCHA site at
 /admin/config/search/gcse-config
 
-Search results will appear at `/results` unless set to another path in the 'internal config'. This is to avoid conflict with `/search` as that path may
+Site search results will appear at `/results` unless set to another path in the
+'internal config'. This is to avoid conflict with `/search` as that path may
 already be defined by other modules.
 
-It requires a GCSE ID, which comes from the Google config page.
-That ID must be added on the module config page.
+OCHA-wide search results will by default appear at `/ocha-wide-results`.
+They can be turned off via the 'Enable tab for OCHA-wide results' checkbox, and
+the path can be configured. Both options on the internal config page.
+
+Site search requires a GCSE ID, which comes from the Google config page.
+That ID must be added on the internal config page.
 
 ### Google config
 
-The 'standard' configuration options are included in an xml file in the
-gcse_config directory. It can be uploaded to a custom search engine via the
-advanced tab in the setup, then the name and description edited accordingly.
+The 'standard' configuration options are included in `example-context-cse.xml
+in the `gcse_config` directory. The file can be uploaded to a custom search
+engine via the advanced tab in the setup. The name and description should be
+edited accordingly.
 
-All the color preferences and some other styling choices are included in a
-css file in the module, so configuration of those in the can be ignored.
+All the color preferences and other styling choices are included in a css file
+in the module, so configuration of those in the google interface can be ignored.
 
 ### Internal config
 
-* The path for the results page for site-only search, if a different path than
-'/results'.
-* The path for the results page for Ocha-wide search, if a different path than
-'/ocha-wide-results'.
-* A descriptive text for the site search results page.
-* A descriptive text for the OCHA-wide search results pages.
-* The GCSE ID for the current site search, found on the Google config page.
-* The GCSE ID for the OCHA-wide search, normally 92f65997481234c49.
+Site search:
+  * The path for the results page for site-only search, if a different path than
+  '/results'.
+  * A descriptive text for the site search results page.
+  * The GCSE ID for the current site search, found on the Google config page.
+OCHA-wide search:
+  * A checkbox to Enable OCHA-wide results - if unchecked, only the site search 
+  will be shown.
+  * The path for the results page for Ocha-wide search, if a different path than
+  '/ocha-wide-results'.
+  * A descriptive text for the OCHA-wide search results pages.
+  * The GCSE ID for the OCHA-wide search. Leave this as the default value for
+  consistency with other sites.

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ already be defined by other modules.
 
 OCHA-wide search results will by default appear at `/ocha-wide-results`.
 They can be turned off via the 'Enable tab for OCHA-wide results' checkbox, and
-the path can be configured. Both options on the internal config page.
+the path can be configured. Both options are on the internal config page.
 
 Site search requires a GCSE ID, which comes from the Google config page.
 That ID must be added on the internal config page.
 
 ### Google config
 
-The 'standard' configuration options are included in `example-context-cse.xml
+The 'standard' configuration options are included in `example-context-cse.xml`
 in the `gcse_config` directory. The file can be uploaded to a custom search
 engine via the advanced tab in the setup. The name and description should be
 edited accordingly.
@@ -71,7 +71,7 @@ Site search:
 OCHA-wide search:
   * A checkbox to Enable OCHA-wide results - if unchecked, only the site search
   will be shown.
-  * The path for the results page for Ocha-wide search, if a different path than
+  * The path for the results page for OCHA-wide search, if a different path than
   '/ocha-wide-results'.
   * A descriptive text for the OCHA-wide search results pages.
   * The GCSE ID for the OCHA-wide search. Leave this as the default value for

--- a/config/install/ocha_search.settings.yml
+++ b/config/install/ocha_search.settings.yml
@@ -20,5 +20,6 @@ mapping:
     type: text
     label: 'Ocha-wide GCSE ID'
 site_results_page_path: results
+enable_ocha_wide_results: 1
 ocha_wide_results_page_path: ocha-wide-results
 ocha_wide_gcse_id: 92f65997481234c49

--- a/ocha_search.module
+++ b/ocha_search.module
@@ -23,6 +23,7 @@ function ocha_search_theme($existing, $type, $theme, $path) {
         'search_text' => NULL,
         'gcse_id' => NULL,
         'scope' => NULL,
+        'enable_ocha_wide_results' => NULL,
         'toggle_link_site_text' => NULL,
         'toggle_link_ocha_text' => NULL,
         'toggle_link_path' => NULL,

--- a/src/Controller/OchaSearchController.php
+++ b/src/Controller/OchaSearchController.php
@@ -28,6 +28,7 @@ class OchaSearchController extends ControllerBase {
       '#title' => $this->t('Site search'),
       '#gcse_id' => $this->config('ocha_search.settings')->get('site_gcse_id'),
       '#scope' => 'site',
+      '#enable_ocha_wide_results' => $this->config('ocha_search.settings')->get('enable_ocha_wide_results'),
       '#toggle_link_site_text' => $this->t('Site-only search'),
       '#toggle_link_ocha_text' => $this->t('OCHA-wide search'),
       '#toggle_link_path' => $toggle_link_path,
@@ -52,6 +53,7 @@ class OchaSearchController extends ControllerBase {
     return [
       '#title' => $this->t('OCHA-wide search'),
       '#scope' => 'ocha-wide',
+      '#enable_ocha_wide_results' => TRUE,
       '#toggle_link_site_text' => $this->t('Site-only search'),
       '#toggle_link_ocha_text' => $this->t('OCHA-wide search'),
       '#toggle_link_path' => $toggle_link_path,

--- a/src/Form/OchaSearchSettingsForm.php
+++ b/src/Form/OchaSearchSettingsForm.php
@@ -39,45 +39,74 @@ class OchaSearchSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config(static::SETTINGS);
 
+    $form['site_results'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Site results'),
+      '#collapsible' => FALSE,
+    ];
+
     $form['site_results_page_path'] = [
       '#type' => 'textfield',
+      '#group' => 'site_results',
       '#title' => $this->t('Site results page path'),
       '#description' => $this->t('The relative path for the site results page, without a leading slash.'),
       '#default_value' => $config->get('site_results_page_path'),
     ];
 
-    $form['ocha_wide_results_page_path'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Ocha-wide results page path'),
-      '#description' => $this->t('The relative path for the Ocha-wide results page, without a leading slash.'),
-      '#default_value' => $config->get('ocha_wide_results_page_path'),
-    ];
-
     $form['search_site_text'] = [
       '#type' => 'textarea',
+      '#group' => 'site_results',
       '#title' => $this->t('Site search page text'),
       '#description' => $this->t('Optional text to add to the site search results page.'),
       '#default_value' => $config->get('search_site_text'),
     ];
 
+    $form['site_gcse_id'] = [
+      '#type' => 'textfield',
+      '#group' => 'site_results',
+      '#title' => $this->t('Site GCSE ID'),
+      '#description' => $this->t('The id of the Google Custom Search Engine for this site only, to be found or configured at https://programmablesearchengine.google.com/'),
+      '#default_value' => $config->get('site_gcse_id'),
+    ];
+
+    $form['enable_ocha_wide_results'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable tab for OCHA-wide results'),
+      '#default_value' => $config->get('enable_ocha_wide_results'),
+    ];
+
+    $form['ocha_wide_results'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('OCHA-wide results'),
+      '#collapsible' => TRUE,
+      '#states' => [
+        'invisible' => [
+          ':input[name="enable_ocha_wide_results"]' => ['checked' => FALSE],
+        ],
+      ],
+    ];
+
+    $form['ocha_wide_results_page_path'] = [
+      '#type' => 'textfield',
+      '#group' => 'ocha_wide_results',
+      '#title' => $this->t('Ocha-wide results page path'),
+      '#description' => $this->t('The relative path for the Ocha-wide results page, without a leading slash.'),
+      '#default_value' => $config->get('ocha_wide_results_page_path'),
+    ];
+
     $form['search_ocha_text'] = [
       '#type' => 'textarea',
+      '#group' => 'ocha_wide_results',
       '#title' => $this->t('OCHA-wide search page text'),
       '#description' => $this->t('Optional text to add to the OCHA-wide search results page.'),
       '#default_value' => $config->get('search_ocha_text'),
     ];
 
-    $form['site_gcse_id'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Site GCSE ID'),
-      '#description' => $this->t('The id of the Google Custom Search Enginefor this site only, to be found at https://programmablesearchengine.google.com/'),
-      '#default_value' => $config->get('site_gcse_id'),
-    ];
-
     $form['ocha_wide_gcse_id'] = [
       '#type' => 'textfield',
+      '#group' => 'ocha_wide_results',
       '#title' => $this->t('Ocha-wide GCSE ID'),
-      '#description' => $this->t('The id of the Google Custom Search Enginefor this site only, to be found at https://programmablesearchengine.google.com/'),
+      '#description' => $this->t('The id of the Google Custom Search Enginefor this OCHA-wide searches. For consistency with other sites, this id should not be changed.'),
       '#default_value' => $config->get('ocha_wide_gcse_id'),
     ];
 
@@ -95,6 +124,7 @@ class OchaSearchSettingsForm extends ConfigFormBase {
       ->set('search_ocha_text', $form_state->getValue('search_ocha_text'))
       ->set('site_gcse_id', $form_state->getValue('site_gcse_id'))
       ->set('ocha_wide_gcse_id', $form_state->getValue('ocha_wide_gcse_id'))
+      ->set('enable_ocha_wide_results', $form_state->getValue('enable_ocha_wide_results'))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/templates/results-page.html.twig
+++ b/templates/results-page.html.twig
@@ -6,6 +6,7 @@
  * Available variables:
  * - gcse_id: ID of Google Custom Search Engine.
  * - scope: 'site' or 'ocha-wide'.
+ * - enable_ocha_wide_results: whether to show ocha-wide results or not..
  * - toggle_link_path: relative url of the other search page.
  * - toggle_link_site_text: text for link to the site search page.
  * - toggle_link_ocha_text: text for link to the OCHA-wide search page.
@@ -22,6 +23,7 @@
 <div class="gcse-results-page">
   <script async defer src="https://cse.google.com/cse.js?cx={{ gcse_id }}"></script>
 
+  {%if enable_ocha_wide_results %}
   <ul class="tabs ocha-search-toggle">
     <li{% if scope == 'site' %} class="is-active"{% endif %}>
       <a href="{% if scope == 'site' %}#{% else %}{{ toggle_link_path }}{% endif %}"{% if scope == 'site' %} class="is-active"{% endif %}>{{ toggle_link_site_text }}{% if scope == 'site' %} <span class="visually-hidden">(active tab)</span>{% endif %}</a>
@@ -30,6 +32,7 @@
       <a href="{% if scope == 'ocha-wide' %}#{% else %}{{ toggle_link_path }}{% endif %}"{% if scope == 'ocha-wide' %} class="is-active"{% endif %}>{{ toggle_link_ocha_text }}{% if scope == 'ocha-wide' %} <span class="visually-hidden">(active tab)</span>{% endif %}</a>
     </li>
   </ul>
+  {% endif %}
 
   {% if search_text %}
     <p class="gcse-search-custom-text">{{ search_text }}</p>


### PR DESCRIPTION
Refs: CD-448

I tested this on my local common design site - there should be a checkbox on the config page to allow turning off and on of the ocha-wide search.

I also cleaned up a little bit - I noticed a few naming inconsistencies which I left alone for the moment so as not to interfere with config of sites already using the module, but nothing serious.